### PR TITLE
Fix OpenSearch link

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -10,7 +10,7 @@
         {% block head_additional %}{% endblock %}
 
         <link rel="search" type="application/opensearchdescription+xml"
-              href="{{ MEDIA_URL }}/opensearch.xml" title="SymPy Gamma" />
+              href="{{ MEDIA_URL }}opensearch.xml" title="SymPy Gamma" />
         <link rel="stylesheet" href="{{ MEDIA_URL }}css/style.css" type="text/css" />
         <link href="http://netdna.bootstrapcdn.com/font-awesome/3.2.1/css/font-awesome.css" rel="stylesheet" />
 
@@ -37,7 +37,7 @@
                 menuSettings: {
                     context: "MathJax",
                     zoom: "Hover",
-                    ALT: true
+                    ALT: trueg
                 },
                 MathZoom: {
                     delay: 100


### PR DESCRIPTION
Remove unneeded slash (/) from OpenSearch metadata link - this was preventing Firefox from easily adding the search engine.
