### PR TITLE
Update Google App Engine SDK version for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ install: "pip install -r requirements.txt --use-mirrors"
 
 before_script:
   - cd ..
-  - wget https://commondatastorage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.4.zip -nv
-  - unzip -q google_appengine_1.9.4.zip
+  - wget https://storage.googleapis.com/appengine-sdks/deprecated/195/google_appengine_1.9.5.zip -nv
+  - unzip -q google_appengine_1.9.5.zip
   - export SDK_LOCATION="$(pwd)/google_appengine"
   - cd $TRAVIS_BUILD_DIR
   - git fetch --tags


### PR DESCRIPTION
Alright, there doesn't seem to be a permalink to the latest version of the SDK. I'm going to use version 1.9.5 as that seems to have a stable link (the latest version does not).
