### PR TITLE
Switch from retired MathJax CDN

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -43,7 +43,7 @@
                 extensions: ["tex2jax.js"]
             });
         </script>
-        <script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_CHTML-full"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_CHTML-full"></script>
     </head>
     <body>
         <div class="menu">


### PR DESCRIPTION
As according to [this announcement](https://www.mathjax.org/cdn-shutting-down/) from MathJax, the official CDN is now retired. Because if this, SymPy Gamma hasn't been working since April 30. This commit switches to [cdnjs.com](cdnjs.com), the CDN recommended by MathJax in the annocement post.