### PR TITLE
Require https

### DIFF
--- a/app.yaml.template
+++ b/app.yaml.template
@@ -19,7 +19,7 @@ handlers:
 
 - url: /.*
   script: main.application
-  secure:always
+  secure: always
 
 libraries:
 - name: django

--- a/app.yaml.template
+++ b/app.yaml.template
@@ -19,6 +19,7 @@ handlers:
 
 - url: /.*
   script: main.application
+  secure:always
 
 libraries:
 - name: django


### PR DESCRIPTION
We now have https for sympygamma.com and www.sympygamma.com (some DNS propagation might still need to take place. It works right now for 8.8.8.8).