### PR TITLE
Use Google Cloud Datastore emulator for development

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,20 +18,16 @@ install:
 before_script:
   - gcloud version || true
   - if [ ! -d "$HOME/google-cloud-sdk/bin" ]; then rm -rf "$HOME/google-cloud-sdk"; curl https://sdk.cloud.google.com | bash > /dev/null; fi
-  # Add gcloud to $PATH
   - source /home/travis/google-cloud-sdk/path.bash.inc
   - gcloud version
   - cd ..
-#  - wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-290.0.1-linux-x86_64.tar.gz
-#  - tar -xvzf google-cloud-sdk-290.0.1-linux-x86_64.tar.gz
-#  - bash google-cloud-sdk/install.sh
   - gcloud components install cloud-datastore-emulator --quiet
   - gcloud beta emulators datastore start &
   - wget https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.90.zip -nv
   - unzip -q google_appengine_1.9.90.zip
   - export SDK_LOCATION="$(pwd)/google_appengine"
   - cd $TRAVIS_BUILD_DIR
-  - python $SDK_LOCATION/dev_appserver.py --skip_sdk_update_check 1 . --env_var DATASTORE_EMULATOR_HOST=localhost:8081 &
+  - python $SDK_LOCATION/dev_appserver.py --skip_sdk_update_check 1 . --env_var DATASTORE_EMULATOR_HOST=localhost:8081 --env_var DATASTORE_USE_PROJECT_ID_AS_APP_ID=true &
   - sleep 10
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: python
 python:
 - '2.7'
 
+cache:
+  directories:
+    - "$HOME/google-cloud-sdk/"
+
 virtualenv:
   system_site_packages: true
 
@@ -12,14 +16,22 @@ install:
   - pip install -r requirements/local_requirements.txt
 
 before_script:
-  - openssl aes-256-cbc -K $encrypted_2fd045226a67_key -iv $encrypted_2fd045226a67_iv
-      -in client-secret.json.enc -out client-secret.json -d
+  - gcloud version || true
+  - if [ ! -d "$HOME/google-cloud-sdk/bin" ]; then rm -rf "$HOME/google-cloud-sdk"; curl https://sdk.cloud.google.com | bash > /dev/null; fi
+  # Add gcloud to $PATH
+  - source /home/travis/google-cloud-sdk/path.bash.inc
+  - gcloud version
   - cd ..
+#  - wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-290.0.1-linux-x86_64.tar.gz
+#  - tar -xvzf google-cloud-sdk-290.0.1-linux-x86_64.tar.gz
+#  - bash google-cloud-sdk/install.sh
+  - gcloud components install cloud-datastore-emulator --quiet
+  - gcloud beta emulators datastore start &
   - wget https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.90.zip -nv
   - unzip -q google_appengine_1.9.90.zip
   - export SDK_LOCATION="$(pwd)/google_appengine"
   - cd $TRAVIS_BUILD_DIR
-  - python $SDK_LOCATION/dev_appserver.py --skip_sdk_update_check 1 . &
+  - python $SDK_LOCATION/dev_appserver.py --skip_sdk_update_check 1 . --env_var DATASTORE_EMULATOR_HOST=localhost:8081 &
   - sleep 10
 
 script:
@@ -27,6 +39,8 @@ script:
   - casperjs test app/test
 
 before_deploy:
+  - openssl aes-256-cbc -K $encrypted_2fd045226a67_key -iv $encrypted_2fd045226a67_iv
+    -in client-secret.json.enc -out client-secret.json -d
   - version=$(if [ ! -z "$TRAVIS_TAG" ]; then echo $(cut -d'-' -f2 <<<"$TRAVIS_TAG"); else echo "$TRAVIS_BRANCH"; fi)
   - echo "Version = $version"
 deploy:
@@ -42,3 +56,8 @@ deploy:
 
 after_deploy:
   - python bin/update_status_on_pr.py
+
+env:
+  global:
+    # Do not prompt for user input when using any SDK methods.
+    - CLOUDSDK_CORE_DISABLE_PROMPTS=1

--- a/README.rst
+++ b/README.rst
@@ -62,6 +62,14 @@ Ref: https://cloud.google.com/appengine/docs/standard/python/tools/using-librari
 
     pip install -r requirements/local_requirements.txt
 
+You will need to install Datastore Emulator as well, which comes from gcloud's SDK,
+install the Google Cloud SDK for your OS from here: https://cloud.google.com/sdk/install
+Then run the following commands to install and run the datastore emulator in the background::
+
+    gcloud components install cloud-datastore-emulator --quiet
+    gcloud beta emulators datastore start &
+
+
 Development server
 ------------------
 

--- a/app.yaml
+++ b/app.yaml
@@ -34,3 +34,4 @@ libraries:
 
 env_variables:
   GOOGLE_APPLICATION_CREDENTIALS: "client-secret.json"
+  PROJECT_ID: "sympy-live-hrd"

--- a/app.yaml
+++ b/app.yaml
@@ -34,4 +34,4 @@ libraries:
 
 env_variables:
   GOOGLE_APPLICATION_CREDENTIALS: "client-secret.json"
-  PROJECT_ID: "sympy-live-hrd"
+  PROJECT_ID: "sympy-gamma-hrd"

--- a/app/models.py
+++ b/app/models.py
@@ -1,10 +1,11 @@
 import six
+import os
 # https://github.com/googleapis/python-ndb/issues/249#issuecomment-560957294
 six.moves.reload_module(six)
 
 from google.cloud import ndb
 
-ndb_client = ndb.Client(project='sympy-live-hrd')
+ndb_client = ndb.Client(project=os.environ['PROJECT_ID'])
 
 
 class Query(ndb.Model):

--- a/app/models.py
+++ b/app/models.py
@@ -4,7 +4,7 @@ six.moves.reload_module(six)
 
 from google.cloud import ndb
 
-ndb_client = ndb.Client()
+ndb_client = ndb.Client(project='sympy-live-hrd')
 
 
 class Query(ndb.Model):


### PR DESCRIPTION
Fixes #147 

NDB Client needs credentials for set up, this is remove the dependency of requiring credentials.
- [x] Use google datastore cloud emulator for testing and development.
- [x] Get `PROJECT_ID` from environment variable.
- [x] Install google cloud SDK in travis.
- [x] Move `client-secret.json` decryption to `before_deploy`.
- [x] Update README