### PR TITLE
Dockerize the project for development

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,39 +2,23 @@ language: python
 python:
 - '2.7'
 
-cache:
-  directories:
-    - "$HOME/google-cloud-sdk/"
-
-virtualenv:
-  system_site_packages: true
+services:
+  - docker
 
 before_install:
-  - npm install -g casperjs
+  - ls
 install:
-  - pip install -r requirements/requirements.txt -t lib/
-  - pip install -r requirements/local_requirements.txt
-
+  - ls
 before_script:
-  - gcloud version || true
-  - if [ ! -d "$HOME/google-cloud-sdk/bin" ]; then rm -rf "$HOME/google-cloud-sdk"; curl https://sdk.cloud.google.com | bash > /dev/null; fi
-  - source /home/travis/google-cloud-sdk/path.bash.inc
-  - gcloud version
-  - cd ..
-  - gcloud components install cloud-datastore-emulator --quiet
-  - gcloud beta emulators datastore start &
-  - wget https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.90.zip -nv
-  - unzip -q google_appengine_1.9.90.zip
-  - export SDK_LOCATION="$(pwd)/google_appengine"
-  - cd $TRAVIS_BUILD_DIR
-  - python $SDK_LOCATION/dev_appserver.py --skip_sdk_update_check 1 . --env_var DATASTORE_EMULATOR_HOST=localhost:8081 --env_var DATASTORE_USE_PROJECT_ID_AS_APP_ID=true &
-  - sleep 10
+  - docker-compose up -d
 
 script:
-  - PYTHONPATH='.' nosetests app/test -vv
-  - casperjs test app/test
+  - sleep 2  # Wait for api to be up
+  - docker-compose exec app nosetests app/test -vv
+  - docker-compose exec app casperjs test app/test
 
 before_deploy:
+  - docker cp app:/usr/src/app/lib lib
   - openssl aes-256-cbc -K $encrypted_2fd045226a67_key -iv $encrypted_2fd045226a67_iv
     -in client-secret.json.enc -out client-secret.json -d
   - version=$(if [ ! -z "$TRAVIS_TAG" ]; then echo $(cut -d'-' -f2 <<<"$TRAVIS_TAG"); else echo "$TRAVIS_BRANCH"; fi)
@@ -52,8 +36,3 @@ deploy:
 
 after_deploy:
   - python bin/update_status_on_pr.py
-
-env:
-  global:
-    # Do not prompt for user input when using any SDK methods.
-    - CLOUDSDK_CORE_DISABLE_PROMPTS=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,4 +35,5 @@ deploy:
     repo: sympy/sympy_gamma
 
 after_deploy:
+  - pip install requests
   - python bin/update_status_on_pr.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ script:
   - docker-compose exec app casperjs test app/test
 
 before_deploy:
-  - docker cp app:/usr/src/app/lib lib
+  - docker cp gamma_app:/usr/src/app/lib lib
   - openssl aes-256-cbc -K $encrypted_2fd045226a67_key -iv $encrypted_2fd045226a67_iv
     -in client-secret.json.enc -out client-secret.json -d
   - version=$(if [ ! -z "$TRAVIS_TAG" ]; then echo $(cut -d'-' -f2 <<<"$TRAVIS_TAG"); else echo "$TRAVIS_BRANCH"; fi)

--- a/README.rst
+++ b/README.rst
@@ -17,79 +17,25 @@ documentation for details). Each result is evaluated in a separate request,
 so (for instance) an integral that takes too long will not prevent the other
 information from loading.
 
-Installation
-------------
-
-Download and unpack most recent Google App Engine SDK for Python from
-https://code.google.com/appengine/downloads.html, e.g.::
-
-    $ wget https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.90.zip
-    $ unzip google_appengine_1.9.90.zip
-
-On the Mac, it is a disk image with an application, which you should
-drag to your Applications folder.  Open the program and install the
-symlinks (it should ask you the first time you open the application, but
-if it doesn't, choose "Make Symlinks..." from the
-GoogleAppEngineLauncher menu).  Note that you will have to do this again
-each time you update the AppEngine program.
-
-Then clone sympy_gamma repository::
-
-    $ git clone git://github.com/sympy/sympy_gamma.git
-    $ cd sympy_gamma
-
-We use submodules to include external libraries in sympy_gamma::
-
-    $ git submodule init
-    $ git submodule update
-
-This is sufficient to clone appropriate repositories in correct versions
-into sympy_gamma (see git documentation on submodules for information).
-
-Install Dependencies
---------------------
-
-The project depends on some third-party libraries that are not on the list
-of built-in libraries (in app.yaml) bundled with the runtime, to install them
-run the following command.::
-
-    pip install -r requirements/requirements.txt -t lib/
-
-Some libraries although available on app engine runtime, but needs to be
-installed locally for development.
-
-Ref: https://cloud.google.com/appengine/docs/standard/python/tools/using-libraries-python-27#local_development ::
-
-    pip install -r requirements/local_requirements.txt
-
-You will need to install Datastore Emulator as well, which comes from gcloud's SDK,
-install the Google Cloud SDK for your OS from here: https://cloud.google.com/sdk/install
-Then run the following commands to install and run the datastore emulator in the background::
-
-    gcloud components install cloud-datastore-emulator --quiet
-    gcloud beta emulators datastore start &
-
-
-Development server
+Development Server
 ------------------
+
+To setup the development environment and run the app locally, you
+need ``docker`` and ``docker-compose``:
+
+* https://docs.docker.com/get-docker/
+* https://docs.docker.com/compose/install/
 
 Now you are ready to run development web server::
 
-    $ ../google_appengine/dev_appserver.py .
+    $ docker-compose up
 
-On the Mac, just run::
+This will build and run the image for app and datastore emulator.
 
-    $ dev_appserver.py .
+This will spin up a local server that runs on port ``8080``.
+Open a web browser and go to http://localhost:8080.
+You should see GUI of SymPy Gamma
 
-(make sure you installed the symlinks as described above).
-
-I couldn't figure out how to make it work in the GUI (it won't find the
-sympy git submodule).  If you figure out how to do it, please update
-this file and send a patch describing how to do it.
-
-This is a local server that runs on port 8080 (use ``--port`` option to
-change this). Open a web browser and go to http://localhost:8080. You
-should see GUI of SymPy Gamma.
 
 Deploying to GAE
 ----------------
@@ -114,6 +60,11 @@ the google cloud console for the project::
 
     $ gcloud init
 
+You need to to create ``lib`` (libraries) before deploying, make sure the development
+server is up and running via ``docker-compose``, as mentioned above and create
+libraries folder to package with the following command::
+
+    $ docker cp app:/usr/src/app/lib lib
 
 Assuming that sympy_gamma works properly (also across different mainstream web
 browsers), you can upload your changes to Google App Engine, replacing the
@@ -161,6 +112,12 @@ Currently, there is no testing server set up as there is for SymPy
 Live. However, you can set up your own testing server (it's free, though it
 requires a cell phone to set up).
 
+You need to to create ``lib`` (libraries) before deploying, make sure the development
+server is up and running via ``docker-compose``, as mentioned above and create
+libraries folder to package with the following command::
+
+    $ docker cp app:/usr/src/app/lib lib
+
 Either way, to test, you will need to edit the Project ID in the deploy command
 mentioned above with your Project ID and the version you want to deploy to::
 
@@ -206,21 +163,11 @@ versions automatically.
 Running Tests
 -------------
 
-To be able to run tests, make sure you have testing libraries installed::
+To run tests you need to spinup the container as mentioned above
+via ``docker-compose`` and run the following command::
 
-    npm install -g casperjs
-    pip install nose
-
-Install phantomjs for your system from: https://phantomjs.org/download.html
-
-To run unit tests::
-
-    PYTHONPATH='.' nosetests app/test -vv
-
-To run PhantomJS Tests::
-
-    casperjs test app/test
-
+    $ docker-compose exec app nosetests app/test -vv
+    $ docker-compose exec app casperjs test app/test
 
 Pulling changes
 ---------------

--- a/README.rst
+++ b/README.rst
@@ -84,7 +84,7 @@ You need to to create ``lib`` (libraries) before deploying, make sure the develo
 server is up and running via ``docker-compose``, as mentioned above and create
 libraries folder to package with the following command::
 
-    $ docker cp app:/usr/src/app/lib lib
+    $ docker cp gamma_app:/usr/src/app/lib lib
 
 Assuming that sympy_gamma works properly (also across different mainstream web
 browsers), you can upload your changes to Google App Engine, replacing the
@@ -136,7 +136,7 @@ You need to to create ``lib`` (libraries) before deploying, make sure the develo
 server is up and running via ``docker-compose``, as mentioned above and create
 libraries folder to package with the following command::
 
-    $ docker cp app:/usr/src/app/lib lib
+    $ docker cp gamma_app:/usr/src/app/lib lib
 
 Either way, to test, you will need to edit the Project ID in the deploy command
 mentioned above with your Project ID and the version you want to deploy to::

--- a/README.rst
+++ b/README.rst
@@ -17,6 +17,23 @@ documentation for details). Each result is evaluated in a separate request,
 so (for instance) an integral that takes too long will not prevent the other
 information from loading.
 
+Installation
+------------
+
+Clone sympy_gamma repository::
+
+    $ git clone git://github.com/sympy/sympy_gamma.git
+    $ cd sympy_gamma
+
+We use submodules to include external libraries in sympy_gamma::
+
+    $ git submodule init
+    $ git submodule update
+
+This is sufficient to clone appropriate repositories in correct versions
+into sympy_gamma (see git documentation on submodules for information).
+
+
 Development Server
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,9 @@
 SymPy Gamma
 ===========
 
+.. image:: https://travis-ci.org/sympy/sympy_gamma.svg?branch=master
+    :target: https://travis-ci.org/sympy/sympy_gamma
+
 `SymPy Gamma <https://www.sympygamma.com>`_ is a simple web application based
 on Google App Engine that executes and displays the results of SymPy
 expressions as well as additional related computations, in a fashion similar

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+version: '3'
+
+services:
+  app:
+    build:
+      context: .
+      dockerfile: ./docker/app/Dockerfile
+    image: app
+    container_name: gamma_app
+    depends_on:
+      - datastore
+    volumes:
+      - ./app/:/usr/src/app/app/
+    ports:
+      - "8080:8080"
+      - "8082:8082"
+      - "8083:8083"
+    command: /run.sh
+
+  datastore:
+    build:
+      context: .
+      dockerfile: ./docker/datastore/Dockerfile
+    image: datastore
+    container_name: gamma_datastore
+    ports:
+      - "8081:8081"

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -39,6 +39,8 @@ RUN rm -rf /usr/local/share/$PHANTOM_JS.tar.bz2
 RUN cd ../ && git clone git://github.com/casperjs/casperjs.git
 RUN cd ../casperjs && ln -sf `pwd`/bin/casperjs /usr/local/bin/casperjs
 
+ENV PYTHONPATH="/usr/src/app"
+
 COPY . .
 
 ENTRYPOINT [ "/run.sh" ]

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -21,7 +21,7 @@ RUN unzip -q /usr/src/google_appengine_1.9.90.zip -d /usr/src/
 ENV SDK_LOCATION="/usr/src/google_appengine"
 
 # Install PhantomJs and Casperjs for Testing
-ENV PHANTOM_JS="phantomjs-1.9.8-linux-x86_64"
+ENV PHANTOM_JS="phantomjs-2.1.1-linux-x86_64"
 RUN apt-get install -y chrpath libssl-dev libxft-dev \
     && apt-get install -y libfreetype6 libfreetype6-dev \
     && apt-get install -y libfontconfig1 libfontconfig1-dev \

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -1,0 +1,44 @@
+FROM python:2-slim
+
+RUN apt-get update \
+  # dependencies for building Python packages
+  && apt-get install -y build-essential \
+  && apt-get install -y python-dev \
+  && apt-get install -y wget \
+  && apt-get install -y zip unzip
+
+WORKDIR /usr/src/app
+
+COPY requirements ./requirements
+COPY ./docker/app/run.sh /run.sh
+
+RUN pip install -r requirements/requirements.txt -t lib/
+RUN pip install -r requirements/local_requirements.txt
+
+# Install App engine SDK
+RUN wget https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.90.zip -nv -P /usr/src/
+RUN unzip -q /usr/src/google_appengine_1.9.90.zip -d /usr/src/
+ENV SDK_LOCATION="/usr/src/google_appengine"
+
+# Install PhantomJs and Casperjs for Testing
+ENV PHANTOM_JS="phantomjs-1.9.8-linux-x86_64"
+RUN apt-get update
+RUN apt-get install -y build-essential chrpath libssl-dev libxft-dev
+RUN apt-get install -y libfreetype6 libfreetype6-dev
+RUN apt-get install -y libfontconfig1 libfontconfig1-dev
+RUN apt-get install -y git
+
+RUN cd ../ && wget https://bitbucket.org/ariya/phantomjs/downloads/$PHANTOM_JS.tar.bz2
+RUN mv ../$PHANTOM_JS.tar.bz2 /usr/local/share/
+RUN cd /usr/local/share/ && tar xvjf $PHANTOM_JS.tar.bz2
+RUN ln -sf /usr/local/share/$PHANTOM_JS/bin/phantomjs /usr/local/share/phantomjs
+RUN ln -sf /usr/local/share/$PHANTOM_JS/bin/phantomjs /usr/local/bin/phantomjs
+RUN ln -sf /usr/local/share/$PHANTOM_JS/bin/phantomjs /usr/bin/phantomjs
+RUN rm -rf /usr/local/share/$PHANTOM_JS.tar.bz2
+
+RUN cd ../ && git clone git://github.com/casperjs/casperjs.git
+RUN cd ../casperjs && ln -sf `pwd`/bin/casperjs /usr/local/bin/casperjs
+
+COPY . .
+
+ENTRYPOINT [ "/run.sh" ]

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -22,11 +22,10 @@ ENV SDK_LOCATION="/usr/src/google_appengine"
 
 # Install PhantomJs and Casperjs for Testing
 ENV PHANTOM_JS="phantomjs-1.9.8-linux-x86_64"
-RUN apt-get update
-RUN apt-get install -y build-essential chrpath libssl-dev libxft-dev
-RUN apt-get install -y libfreetype6 libfreetype6-dev
-RUN apt-get install -y libfontconfig1 libfontconfig1-dev
-RUN apt-get install -y git
+RUN apt-get install -y chrpath libssl-dev libxft-dev \
+    && apt-get install -y libfreetype6 libfreetype6-dev \
+    && apt-get install -y libfontconfig1 libfontconfig1-dev \
+    && apt-get install -y git
 
 RUN cd ../ && wget https://bitbucket.org/ariya/phantomjs/downloads/$PHANTOM_JS.tar.bz2
 RUN mv ../$PHANTOM_JS.tar.bz2 /usr/local/share/
@@ -36,8 +35,8 @@ RUN ln -sf /usr/local/share/$PHANTOM_JS/bin/phantomjs /usr/local/bin/phantomjs
 RUN ln -sf /usr/local/share/$PHANTOM_JS/bin/phantomjs /usr/bin/phantomjs
 RUN rm -rf /usr/local/share/$PHANTOM_JS.tar.bz2
 
-RUN cd ../ && git clone git://github.com/casperjs/casperjs.git
-RUN cd ../casperjs && ln -sf `pwd`/bin/casperjs /usr/local/bin/casperjs
+RUN cd ../ && git clone git://github.com/casperjs/casperjs.git \
+    && cd casperjs && ln -sf `pwd`/bin/casperjs /usr/local/bin/casperjs
 
 ENV PYTHONPATH="/usr/src/app"
 

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -21,7 +21,7 @@ RUN unzip -q /usr/src/google_appengine_1.9.90.zip -d /usr/src/
 ENV SDK_LOCATION="/usr/src/google_appengine"
 
 # Install PhantomJs and Casperjs for Testing
-ENV PHANTOM_JS="phantomjs-2.1.1-linux-x86_64"
+ENV PHANTOM_JS="phantomjs-1.9.8-linux-x86_64"
 RUN apt-get install -y chrpath libssl-dev libxft-dev \
     && apt-get install -y libfreetype6 libfreetype6-dev \
     && apt-get install -y libfontconfig1 libfontconfig1-dev \

--- a/docker/app/run.sh
+++ b/docker/app/run.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+HOST="0.0.0.0"
+API_PORT="8082"
+ADMIN_PORT="8083"
+DATASTORE_EMULATOR_HOST_PORT=datastore:8081
+
+python $SDK_LOCATION/dev_appserver.py --api_host 0.0.0.0 \
+ --api_port "$API_PORT" \
+ --admin_host "$HOST" \
+ --admin_port "$ADMIN_PORT" \
+ --host "$HOST" \
+ --skip_sdk_update_check 1 . \
+ --env_var DATASTORE_EMULATOR_HOST="$DATASTORE_EMULATOR_HOST_PORT" \
+ --env_var DATASTORE_USE_PROJECT_ID_AS_APP_ID=true

--- a/docker/datastore/Dockerfile
+++ b/docker/datastore/Dockerfile
@@ -1,0 +1,8 @@
+FROM google/cloud-sdk:latest
+
+WORKDIR /usr/src/app
+COPY ./docker/datastore/run.sh ./run.sh
+
+ENV CLOUDSDK_CORE_PROJECT=sympy-live-hrd
+
+ENTRYPOINT [ "./run.sh" ]

--- a/docker/datastore/run.sh
+++ b/docker/datastore/run.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+gcloud beta emulators datastore start --host-port=0.0.0.0:8081


### PR DESCRIPTION
Setting up the project is pain at the moment, which is a huge hindrance for someone trying to contribute to this project. The aim of this pull request is to make setting up and development of the project trivial.

- [x] Docker container for datastore emulator and app
- [x] Testing tools inside the container like: CasperJS, PhantomJS
- [x] Hot reloading for quick iteration during development
- [x] Cleanup Travis
- [x] Update `README`