### PR TITLE
Refactor MultiResultCard to remove implicit state

### DIFF
--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -28,7 +28,7 @@ RUN ln -sf /usr/local/share/$PHANTOM_JS/bin/phantomjs /usr/local/bin/phantomjs
 RUN ln -sf /usr/local/share/$PHANTOM_JS/bin/phantomjs /usr/bin/phantomjs
 RUN rm -rf /usr/local/share/$PHANTOM_JS.tar.bz2
 
-RUN cd ../ && git clone git://github.com/casperjs/casperjs.git \
+RUN cd ../ && git clone https://github.com/casperjs/casperjs.git \
     && cd casperjs && ln -sf `pwd`/bin/casperjs /usr/local/bin/casperjs
 
 ENV PYTHONPATH="/usr/src/app"


### PR DESCRIPTION
This changes the design of the `MultiResultCard` class to make state more explicit, as was requested in a "TODO" comment. It does this by adding the `CardResult` class to encapsulate the relevant state of a card evaluation in a single object.

The `eval` method now creates `CardResult` objects and adds them to a list of `results` instead of tuples, and it checks for the presence of `card_result` objects in `results` using the `__eq__` method defined in the `CardResult` class.

The `format_output` method now takes a list of `CardResult` objects instead of tuples, and uses the `card_result` object's attributes to generate the formatted output.